### PR TITLE
Adjust headers for consistency across pages

### DIFF
--- a/pages/chapters.vue
+++ b/pages/chapters.vue
@@ -4,16 +4,16 @@ let {data: chapters} = await useFetch("/api/chapters")
 </script>
 
 <template>
+  <header>
+      <NuxtLink to="/cover" id="link-back-chapters" class="absolute">
+          <Button icon="pi pi-angle-left" class="forefront" text></Button>
+      </NuxtLink>
+      <div class="flex align-items-center justify-content-around">
+        <h2>CHAPTERS</h2>
+      </div>
+  </header>
   <div>
     <DataView :value="chapters" :data-key="'id'" layout="grid">
-      <template #header>
-        <NuxtLink to="/cover" id="link-back-chapters" class="absolute">
-        <Button icon="pi pi-angle-left" class="forefront" text></Button>
-        </NuxtLink>
-        <div class="flex align-items-center justify-content-around">
-        <h2>Chapters</h2>
-      </div>
-      </template>
       <template #grid="slotProps">
         <NuxtLink :to="'/reader/' + slotProps.data.chapter_number" class="col-6 sm:col-4 md:col-3 lg:col-2 flex-none p-2 border-round">
           <Card>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div class="h-screen">
-    <div class="flex align-items-center justify-content-around title">
+    <div class="flex align-items-center justify-content-around">
       <h2>HIME BIRTHDAY PROJECT 2023</h2>
     </div>
     <div class="flex flex-wrap align-items-center justify-content-around content mb-8">

--- a/pages/messages.vue
+++ b/pages/messages.vue
@@ -1,10 +1,15 @@
 <script setup></script>
 
 <template>
+  <header>
+      <NuxtLink to="/" id="link-back-messages" class="absolute">
+          <Button icon="pi pi-angle-left" class="forefront" text></Button>
+      </NuxtLink>
+      <div class="flex align-items-center justify-content-around">
+        <h2>BIRTHDAY MESSAGES</h2>
+      </div>
+  </header>
   <div>
-    <NuxtLink to="/" id="link-back-messages">
-      <Button icon="pi pi-angle-left" class="forefront" text></Button>
-    </NuxtLink>
     <!-- Need to connect to database -->
     <ul>
         <li>Place holder for images</li>


### PR DESCRIPTION
Based on current header design from cover. 
This should fix the size and location difference of the back navigation arrow on the chapter list page.